### PR TITLE
Update media_player.pioneer.markdown for PR #16604

### DIFF
--- a/source/_components/media_player.pioneer.markdown
+++ b/source/_components/media_player.pioneer.markdown
@@ -32,6 +32,27 @@ Configuration variables:
 - **port** (*Optional*): The port on which the Pioneer device listens, e.g., `23` (default) or `8102`
 - **timeout** (*Optional*): Number of seconds (float) to wait for blocking operations like connect, write, and read.
 
+
+For older Pioneer receivers that do not work with the default configuration (due to not supporting input labels), you can fall back to a more basic mode using these additional configuration variables.  If the component works correctly with just the host/name/port then don't use this.
+
+- **mode** (*Required*): `basic`
+- **input** (*Optional*): A list of reciever input numbers and their associated name.  If this is left out you will still get automatic labels like "Input 06".  The numbers seem to vary between devices, so you will need to configure this yourself to match your receiver.
+To find the input numbers, either telnet to the receiver and watch the messages when changing inputs, or run this component without `input` configured and see what gets detected.
+
+```yaml
+media_player:
+  - platform: pioneer
+    host: 192.168.0.10
+    mode: basic
+    input:
+      02:
+        name: "Tuner"
+      06:
+        name: "PC"
+      15:
+        name: "FireTV"
+```
+
 Notes:
 
 - Some Pioneer AVRs use the port 23 default and some are reported to use 8102.


### PR DESCRIPTION
Support basic mode for additional Pioneer receivers that do not work with the existing platform. This includes at least VSX-822/1022 and presumably other pre-2013 devices.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
